### PR TITLE
Add enhancements to Razor functionality

### DIFF
--- a/sample/AspNet.Mvc/Controllers/HomeController.cs
+++ b/sample/AspNet.Mvc/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
 ﻿using DnxFlash;
+using DnxFlash.Extensions;
 using Microsoft.AspNet.Mvc;
 using System;
 
@@ -17,9 +18,13 @@ namespace AspNet.Mvc.Controllers
         {
             if (throwException)
             {
-                messenger.Add(new Message(
+                //messenger.Add(new Message(
+                //    text: $"Application exception occured @ {DateTimeOffset.UtcNow}.",
+                //    title: "Error"));
+
+                messenger.Error(
                     text: $"Application exception occured @ {DateTimeOffset.UtcNow}.",
-                    title: "Error"));
+                    title: "Error");
 
                 throw new ApplicationException("A message has been created. Go back to the previous page and refresh to see the message.");
             }
@@ -29,9 +34,13 @@ namespace AspNet.Mvc.Controllers
 
         public IActionResult Post()
         {
-            messenger.Add(new Message(
+            //messenger.Add(new Message(
+            //    text: $"Form posted @ {DateTimeOffset.UtcNow}. Going to redirect.",
+            //    title: "Form post successful"));
+
+            messenger.Success(
                 text: $"Form posted @ {DateTimeOffset.UtcNow}. Going to redirect.",
-                title: "Form post successful"));
+                title: "Form post successful");
 
             return RedirectToAction("Index");
         }

--- a/sample/AspNet.Mvc/Startup.cs
+++ b/sample/AspNet.Mvc/Startup.cs
@@ -46,7 +46,7 @@ namespace AspNet.Mvc
 
             services.AddScoped<IMessageTypes>(x =>
             {
-                return new MessageTypes();
+                return new MessageTypes(error: "danger");
             });
 
             services.AddScoped<IMessengerOptions>(x =>

--- a/sample/AspNet.Mvc/Views/Shared/Components/DnxFlash/Bootstrap.cshtml
+++ b/sample/AspNet.Mvc/Views/Shared/Components/DnxFlash/Bootstrap.cshtml
@@ -1,0 +1,12 @@
+@model IEnumerable<DnxFlash.Message>
+
+@foreach (var message in Model)
+{
+    <div class="alert alert-@message.Type.ToLower()" role="alert">
+        @if (!string.IsNullOrWhiteSpace(message.Title))
+        {
+            <strong>@message.Title</strong><text>&nbsp;</text>
+        }
+        @message.Text
+    </div>
+}

--- a/sample/AspNet.Mvc/Views/Shared/_Layout.cshtml
+++ b/sample/AspNet.Mvc/Views/Shared/_Layout.cshtml
@@ -36,7 +36,7 @@
             </div>
         </div>
         <div class="container body-content">
-            @Component.Invoke("DnxFlash")
+            @Component.DnxFlash()
             @RenderBody()
             <hr />
             <footer>

--- a/sample/AspNet.Mvc/Views/_ViewImports.cshtml
+++ b/sample/AspNet.Mvc/Views/_ViewImports.cshtml
@@ -1,3 +1,5 @@
 ﻿@using AspNet.Mvc
+@using DnxFlash.AspNet.Razor.ViewHelpers
+@using DnxFlash.AspNet.Razor.ViewHelpers.Extensions
 @using Microsoft.Framework.OptionsModel
 @addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"

--- a/sample/AspNet.Mvc/gulpfile.js
+++ b/sample/AspNet.Mvc/gulpfile.js
@@ -27,7 +27,7 @@ gulp.task("copy", ["clean"], function () {
   }
 
   var linkedFiles = {
-      "Views/Shared/Components/DnxFlash/": "../../src/DnxFlash.AspNet.Razor.ViewHelpers/Views/Shared/Components/DnxFlash/Default.cshtml"
+      "Views/Shared/Components/DnxFlash/": "../../src/DnxFlash.AspNet.Razor.ViewHelpers/Views/Shared/Components/DnxFlash/*.cshtml"
   };
 
   for (var linkedFile in linkedFiles) {

--- a/src/DnxFlash.AspNet.Razor.ViewHelpers/Extensions/IViewComponentHelperExtensions.cs
+++ b/src/DnxFlash.AspNet.Razor.ViewHelpers/Extensions/IViewComponentHelperExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNet.Mvc;
+using Microsoft.AspNet.Mvc.Rendering;
+
+namespace DnxFlash.AspNet.Razor.ViewHelpers.Extensions
+{
+    public static class IViewComponentHelperExtensions
+    {
+        public static HtmlString DnxFlash(
+            this IViewComponentHelper value,
+            string view = null)
+        {
+            if (string.IsNullOrWhiteSpace(view))
+            {
+                return value.Invoke<DnxFlashViewComponent>();
+            }
+            else
+            {
+                return value.Invoke<DnxFlashViewComponent>(view);
+            }
+        }
+    }
+}

--- a/src/DnxFlash.AspNet.Razor.ViewHelpers/Views/Shared/Components/DnxFlash/Bootstrap.cshtml
+++ b/src/DnxFlash.AspNet.Razor.ViewHelpers/Views/Shared/Components/DnxFlash/Bootstrap.cshtml
@@ -1,0 +1,12 @@
+﻿@model IEnumerable<DnxFlash.Message>
+
+@foreach (var message in Model)
+{
+    <div class="alert alert-@message.Type.ToLower()" role="alert">
+        @if (!string.IsNullOrWhiteSpace(message.Title))
+        {
+            <strong>@message.Title</strong><text>&nbsp;</text>
+        }
+        @message.Text
+    </div>
+}

--- a/src/DnxFlash/Extensions/IMessengerExtensions.cs
+++ b/src/DnxFlash/Extensions/IMessengerExtensions.cs
@@ -1,0 +1,56 @@
+﻿namespace DnxFlash.Extensions
+{
+    public static class IMessengerExtensions
+    {
+        public static IMessenger Error(
+            this IMessenger value,
+            string text,
+            string title = null)
+        {
+            return value.AddMessage(text, value.Options.MessageTypes.Error, title);
+        }
+
+        public static IMessenger Information(
+            this IMessenger value,
+            string text,
+            string title = null)
+        {
+            return value.AddMessage(text, value.Options.MessageTypes.Information, title);
+        }
+
+        public static IMessenger Notice(
+            this IMessenger value,
+            string text,
+            string title = null)
+        {
+            return value.AddMessage(text, value.Options.MessageTypes.Notice, title);
+        }
+
+        public static IMessenger Success(
+            this IMessenger value,
+            string text,
+            string title = null)
+        {
+            return value.AddMessage(text, value.Options.MessageTypes.Success, title);
+        }
+
+        public static IMessenger Warning(
+            this IMessenger value,
+            string text,
+            string title = null)
+        {
+            return value.AddMessage(text, value.Options.MessageTypes.Warning, title);
+        }
+
+        private static IMessenger AddMessage(
+            this IMessenger value,
+            string text,
+            string type,
+            string title = null)
+        {
+            value.Add(new Message(text, title, type));
+
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
New behavior uses extention method on `IViewComponentHelper` instead of relying on the latter's `Invoke` method.
Also including Bootstrap-baked view.
Add extension methods to `IMessenger` for type-specific messages (i.e. success, error, notice).
