### PR TITLE
Update ViewHelpers project to allow dnxcore

### DIFF
--- a/src/DnxFlash.AspNet.MessageProviders/project.json
+++ b/src/DnxFlash.AspNet.MessageProviders/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.4.0-*",
+    "version": "0.5.0-*",
     "description": "Leverages DNXFlash and contains useful message providers for AspNet.",
     "authors": [ "Bill Boga" ],
     "tags": [ "dnx aspnet mvc" ],
@@ -7,7 +7,7 @@
     "licenseUrl": "https://raw.githubusercontent.com/billboga/dnxflash/master/LICENSE",
 
     "dependencies": {
-        "DnxFlash": "0.4.0-*",
+        "DnxFlash": "0.5.0-*",
         "Microsoft.AspNet.Http.Features": "1.0.0-rc1-final",
         "Newtonsoft.Json": "7.0.1"
     },

--- a/src/DnxFlash.AspNet.Razor.ViewHelpers/project.json
+++ b/src/DnxFlash.AspNet.Razor.ViewHelpers/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "0.4.0-*",
+    "version": "0.5.0-*",
     "description": "Leverages DNXFlash and contains useful view helpers for Razor.",
     "authors": [ "Bill Boga" ],
     "tags": [ "dnx aspnet flash razor" ],
@@ -7,12 +7,13 @@
     "licenseUrl": "https://raw.githubusercontent.com/billboga/dnxflash/master/LICENSE",
 
     "dependencies": {
-        "DnxFlash": "0.4.0-*",
+        "DnxFlash": "0.5.0-*",
         "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
         "Microsoft.AspNet.Mvc.ViewFeatures": "6.0.0-rc1-final"
     },
 
     "frameworks": {
-        "dnx451": { }
+        "dnx451": { },
+        "dnxcore50": { }
     }
 }

--- a/src/DnxFlash/project.json
+++ b/src/DnxFlash/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "0.4.0-*",
+    "version": "0.5.0-*",
     "description": "Provides a foundation for managing flash messages.",
     "authors": [ "Bill Boga" ],
     "tags": [ "dnx flash" ],


### PR DESCRIPTION
Previous behavior only targeted net451, but the library was already compatible with both.
